### PR TITLE
example/asicwaves.rb

### DIFF
--- a/examples/asicwaves.rb
+++ b/examples/asicwaves.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require 'mindwave'
+
+class EEG < Mindwave::Headset
+  # override Attention-Callback-Method
+  def asicCall(asic)
+    puts "DEBUG: ASIC array: #{asic}\n"
+    # assign #{asic} to the array 'a'
+    a = "#{asic}"
+    # strip off square brackets
+    a = a.delete! '[]'
+    # convert to array of integers
+    a = a.split(",").map(&:to_i)
+
+    # define wave values
+    delta     = convertToBigEndianInteger(a[0..3])
+    theta     = convertToBigEndianInteger(a[3..6])
+    lowAlpha  = convertToBigEndianInteger(a[6..9])
+    highAlpha = convertToBigEndianInteger(a[9..12])
+    lowBeta   = convertToBigEndianInteger(a[12..15])
+    highBeta  = convertToBigEndianInteger(a[15..18])
+    lowGamma  = convertToBigEndianInteger(a[18..21])
+    midGamma  = convertToBigEndianInteger(a[21..24])
+
+    puts "delta:     #{delta}"
+    puts "theta:     #{theta}"
+    puts "lowAlpha:  #{lowAlpha}"
+    puts "highAlpha: #{highAlpha}"
+    puts "lowBeta:   #{lowBeta}"
+    puts "highBeta:  #{highBeta}"
+    puts "lowGamma:  #{lowGamma}"
+    puts "midGamma:  #{midGamma}"
+  end
+
+  def convertToBigEndianInteger(threeBytes)
+    # see MindwaveDataPoints.py at
+    # https://github.com/robintibor/python-mindwave-mobile
+    #
+    bigEndianInteger = (threeBytes[0] << 16) |\
+     (((1 << 16) - 1) & (threeBytes[1] << 8)) |\
+      ((1 << 8) -1) & threeBytes[2]
+    return bigEndianInteger
+  end
+
+end
+
+# create a new instance
+mw = EEG.new
+# mw.log.level = Logger::DEBUG
+
+# if we hit ctrl+c then just stop the run()-method
+Signal.trap("INT") do
+	mw.stop
+end
+
+# Create a new Thread
+thread = Thread.new { mw.run }
+# ..and run it
+thread.join
+
+
+mw.close

--- a/examples/asicwaves.rb
+++ b/examples/asicwaves.rb
@@ -6,42 +6,21 @@ require 'mindwave'
 class EEG < Mindwave::Headset
   # override Attention-Callback-Method
   def asicCall(asic)
+
     puts "DEBUG: ASIC array: #{asic}\n"
-    # assign #{asic} to the array 'a'
-    a = "#{asic}"
-    # strip off square brackets
-    a = a.delete! '[]'
-    # convert to array of integers
-    a = a.split(",").map(&:to_i)
 
-    # define wave values
-    delta     = convertToBigEndianInteger(a[0..3])
-    theta     = convertToBigEndianInteger(a[3..6])
-    lowAlpha  = convertToBigEndianInteger(a[6..9])
-    highAlpha = convertToBigEndianInteger(a[9..12])
-    lowBeta   = convertToBigEndianInteger(a[12..15])
-    highBeta  = convertToBigEndianInteger(a[15..18])
-    lowGamma  = convertToBigEndianInteger(a[18..21])
-    midGamma  = convertToBigEndianInteger(a[21..24])
+    # pass asic to parseASIC and store result
+    parsed = parseASIC(asic)
 
-    puts "delta:     #{delta}"
-    puts "theta:     #{theta}"
-    puts "lowAlpha:  #{lowAlpha}"
-    puts "highAlpha: #{highAlpha}"
-    puts "lowBeta:   #{lowBeta}"
-    puts "highBeta:  #{highBeta}"
-    puts "lowGamma:  #{lowGamma}"
-    puts "midGamma:  #{midGamma}"
-  end
-
-  def convertToBigEndianInteger(threeBytes)
-    # see MindwaveDataPoints.py at
-    # https://github.com/robintibor/python-mindwave-mobile
-    #
-    bigEndianInteger = (threeBytes[0] << 16) |\
-     (((1 << 16) - 1) & (threeBytes[1] << 8)) |\
-      ((1 << 8) -1) & threeBytes[2]
-    return bigEndianInteger
+    # print the values of the waves to STDOUT
+    puts "delta:     #{parsed[0]}"
+    puts "theta:     #{parsed[1]}"
+    puts "lowAlpha:  #{parsed[2]}"
+    puts "highAlpha: #{parsed[3]}"
+    puts "lowBeta:   #{parsed[4]}"
+    puts "highBeta:  #{parsed[5]}"
+    puts "lowGamma:  #{parsed[6]}"
+    puts "midGamma:  #{parsed[7]}"
   end
 
 end

--- a/lib/mindwave.rb
+++ b/lib/mindwave.rb
@@ -376,6 +376,33 @@ def parse_payload(payload)
 
 end
 
+# this method parses the raw ASIC values and returns the values of each
+# of the wave types
+def parseASIC(asic)
+    # assign #{asic} to the array 'a'
+    a = "#{asic}"
+    # strip off square brackets
+    a = a.delete! '[]'
+    # convert to array of integers
+    a = a.split(",").map(&:to_i)
+
+    # define wave values
+    delta     = convertToBigEndianInteger(a[0..3])
+    theta     = convertToBigEndianInteger(a[3..6])
+    lowAlpha  = convertToBigEndianInteger(a[6..9])
+    highAlpha = convertToBigEndianInteger(a[9..12])
+    lowBeta   = convertToBigEndianInteger(a[12..15])
+    highBeta  = convertToBigEndianInteger(a[15..18])
+    lowGamma  = convertToBigEndianInteger(a[18..21])
+    midGamma  = convertToBigEndianInteger(a[21..24])
+
+    # stuff wave values in array
+    asicArray = [delta,theta,lowAlpha,highAlpha,lowBeta,highBeta,lowGamma,midGamma]
+    
+    # return array of wave values
+    return asicArray
+end
+
 # this method sends a byte to the serial connection
 # (Mindwave only)
 #
@@ -533,6 +560,24 @@ def convertRaw(rawval1,rawval2)
 
 	return raw
 end
+
+# converts a raw ASIC power packet of three bytes to a single value
+#
+# @param [Integer] threeBytes[0] first byte-packet of the ASIC wave code
+# @param [Integer] threeBytes[1] second byte-packet of the ASIC wave code
+# @param [Integer] threeBytes[2] third byte-packet of the ASIC wave code
+#
+# @return [Integer] single value generated from the 3 bytes
+def convertToBigEndianInteger(threeBytes)
+  # see MindwaveDataPoints.py at
+  # https://github.com/robintibor/python-mindwave-mobile
+  #
+  bigEndianInteger = (threeBytes[0] << 16) |\
+   (((1 << 16) - 1) & (threeBytes[1] << 8)) |\
+    ((1 << 8) -1) & threeBytes[2]
+  return bigEndianInteger
+end
+
 
 end
 end

--- a/lib/mindwave.rb
+++ b/lib/mindwave.rb
@@ -126,7 +126,7 @@ attr_accessor :headsetid, :device, :rate, :log
 #   stores the current heart-value
 # @!attribute [r] runner
 #   @see #stop
-attr_reader :attention, :meditation, :asic,:poor, :headsetstatus, :heart, :runner
+attr_reader :attention, :meditation, :asic, :poor, :headsetstatus, :heart, :runner
 
 # If connectserial is true, then this constructor opens a serial connection 
 # and automatically connects to the headset


### PR DESCRIPTION
Hi. I create an example file in the fashion of your example. This file is called asicwaves.rb.

I haven't been able to test the file as I don't have my Mindwave Mobile headset with me at work, but it does work with a dummy array passed to the new method (also in the example file) called convertToBigEndianInteger.

I stole that method wholesale from a project on get hub called python-mindwave-mobile (https://github.com/robintibor/python-mindwave-mobile).

I must admit to being a bit confused as to where convertToBigEndianInteger() should live. I suspect it should live in lib/mindwave.rb, but I am unsure. Should it be a private method like the eSenseStr method?

I didn't want to just drop it into the library. By your code, you look to be a much more advanced Rubyist than I, so I thought I'd run this by you first.

Anyway, please take a look at the code at your leisure and let me know what you think if you don't mind.

I hope this finds you well.
